### PR TITLE
Potential fix for code scanning alert no. 18: Incomplete URL substring sanitization

### DIFF
--- a/modules/sfp_wikileaks.py
+++ b/modules/sfp_wikileaks.py
@@ -11,6 +11,7 @@
 # -------------------------------------------------------------------------------
 
 import datetime
+from urllib.parse import urlparse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers, SpiderFootPlugin
 
@@ -124,7 +125,8 @@ class sfp_wikileaks(SpiderFootPlugin):
 
             for link in links:
                 # We can safely skip search.wikileaks.org and others.
-                if "search.wikileaks.org/" in link:
+                from urllib.parse import urlparse
+                if urlparse(link).hostname == "search.wikileaks.org":
                     continue
 
                 if "wikileaks.org/" not in link and "cryptome.org/" not in link:


### PR DESCRIPTION
Potential fix for [https://github.com/anubissbe/spiderfoot/security/code-scanning/18](https://github.com/anubissbe/spiderfoot/security/code-scanning/18)

To fix the issue, the code should parse the URL using Python's `urllib.parse` module and check the hostname explicitly. This ensures that the check is performed on the correct part of the URL and avoids false positives caused by substrings appearing in unexpected locations.

**Steps to fix:**
1. Import the `urlparse` function from the `urllib.parse` module.
2. Replace the substring check (`"search.wikileaks.org/" in link`) with a check on the hostname of the parsed URL.
3. Ensure that the hostname matches `search.wikileaks.org` exactly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Import and use urllib.parse.urlparse to check link.hostname exactly equals search.wikileaks.org instead of substring matching to skip those links.