### PR TITLE
Potential fix for code scanning alert no. 20: Default version of SSL/TLS may be insecure

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -969,7 +969,9 @@ class SpiderFoot:
         s = socket.socket()
         s.settimeout(int(timeout))
         s.connect((host, int(port)))
-        sock = ssl.wrap_socket(s)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        sock = context.wrap_socket(s, server_hostname=host)
         sock.do_handshake()
         return sock
 


### PR DESCRIPTION
Potential fix for [https://github.com/anubissbe/spiderfoot/security/code-scanning/20](https://github.com/anubissbe/spiderfoot/security/code-scanning/20)

To fix the issue, we will replace the use of `ssl.wrap_socket` with a more secure and modern approach. Specifically, we will use `ssl.SSLContext` to create a secure SSL/TLS connection. This allows us to explicitly specify the minimum protocol version (e.g., `ssl.TLSVersion.TLSv1_2`) and configure other security options as needed.

Steps:
1. Replace the `ssl.wrap_socket` call with an `ssl.SSLContext` object.
2. Configure the `SSLContext` to use a secure protocol by setting `minimum_version` to `ssl.TLSVersion.TLSv1_2`.
3. Use the `wrap_socket` method of the `SSLContext` object to wrap the socket securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace ssl.wrap_socket call with SSLContext(PROTOCOL_TLS_CLIENT) and enforce minimum TLSv1.2