### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete URL substring sanitization

### DIFF
--- a/modules/sfp_webserver.py
+++ b/modules/sfp_webserver.py
@@ -123,8 +123,10 @@ class sfp_webserver(SpiderFootPlugin):
         if cookies and 'JSESSIONID' in cookies:
             tech.append("Java/JSP")
 
-        if cookies and 'ASP.NET' in cookies:
-            tech.append("ASP.NET")
+        if cookies:
+            cookie_pairs = [cookie.strip().split('=') for cookie in cookies.split(';')]
+            if any(cookie[0] == 'ASP.NET' for cookie in cookie_pairs if len(cookie) > 1):
+                tech.append("ASP.NET")
 
         if '.asp' in eventSource:
             tech.append("ASP")


### PR DESCRIPTION
Potential fix for [https://github.com/anubissbe/spiderfoot/security/code-scanning/17](https://github.com/anubissbe/spiderfoot/security/code-scanning/17)

To fix the issue, we should parse the cookies properly and check for the presence of "ASP.NET" in a structured and context-aware manner. Instead of performing a substring match, we can split the cookies into individual key-value pairs and check if any of the keys explicitly match "ASP.NET". This ensures that the check is precise and avoids false positives caused by substring matches in unrelated parts of the cookie string.

The changes will involve:
1. Parsing the `cookies` string into individual cookie components.
2. Checking if any cookie key explicitly matches "ASP.NET".
3. Updating the logic to append "ASP.NET" to the `tech` list only when the match is confirmed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Refine ASP.NET technology detection by parsing cookies into key-value pairs and requiring an exact cookie name match to avoid substring false positives.

Bug Fixes:
- Prevent false positives in ASP.NET detection by replacing substring matching with an exact cookie key check.

Enhancements:
- Parse the Cookie header into individual key-value pairs for more precise technology identification.